### PR TITLE
Actually suppress php 8.1 deprecation warnings

### DIFF
--- a/src/Httpful/Response/Headers.php
+++ b/src/Httpful/Response/Headers.php
@@ -64,6 +64,7 @@ final class Headers implements \ArrayAccess, \Countable {
      * @param string $offset
      * @param string $value
      * @throws \Exception
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
@@ -74,6 +75,7 @@ final class Headers implements \ArrayAccess, \Countable {
     /**
      * @param string $offset
      * @throws \Exception
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetUnset($offset)


### PR DESCRIPTION
Ensure ReturnTypeWillChange is used in conjunction with @return to suppress deprecation warnings